### PR TITLE
Render in

### DIFF
--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -18,5 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.5'
+
   s.add_dependency("activesupport", ">= 3.0.0")
+  s.add_dependency("ruby2_keywords", ">= 0.0.2")
 end

--- a/lib/arbre.rb
+++ b/lib/arbre.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string/output_safety'
+require 'active_support/deprecation'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/inflector'
 

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -1,4 +1,5 @@
 require 'arbre/element'
+require 'ruby2_keywords'
 
 module Arbre
 
@@ -74,7 +75,7 @@ module Arbre
     # Webservers treat Arbre::Context as a string. We override
     # method_missing to delegate to the string representation
     # of the html.
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       if cached_html.respond_to? method
         cached_html.send method, *args, &block
       else

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -95,7 +95,7 @@ module Arbre
     alias_method :within, :with_current_arbre_element
 
     def output_buffer
-      @output_buffer ||= StringIO.new
+      @output_buffer ||= ActiveSupport::SafeBuffer.new
     end
 
     private

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -94,6 +94,10 @@ module Arbre
     end
     alias_method :within, :with_current_arbre_element
 
+    def output_buffer
+      @output_buffer ||= StringIO.new
+    end
+
     private
 
 

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -107,7 +107,7 @@ module Arbre
       if defined?(@cached_html)
         @cached_html
       else
-        html = to_s
+        html = render_in(self)
         @cached_html = html if html.length > 0
         html
       end

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -132,14 +132,16 @@ module Arbre
     end
 
     def inspect
-      to_s
+      content
     end
 
     def to_str
-      to_s
+      ActiveSupport::Deprecation.warn("don't rely on implicit conversion of Element to String")
+      content
     end
 
     def to_s
+      ActiveSupport::Deprecation.warn("#render_in should be defined for rendering #{method_owner(:to_s)} instead of #to_s")
       content
     end
 

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -155,6 +155,7 @@ module Arbre
       if method_distance(:render_in) <= method_distance(:to_s)
         render_in(context)
       else
+        ActiveSupport::Deprecation.warn("#render_in should be defined for rendering #{method_owner(:to_s)} instead of #to_s")
         to_s.tap { |s| context.output_buffer << s }
       end
     end

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -1,6 +1,7 @@
 require 'arbre/element/builder_methods'
 require 'arbre/element/proxy'
 require 'arbre/element_collection'
+require 'ruby2_keywords'
 
 module Arbre
 
@@ -191,7 +192,7 @@ module Arbre
     #  3. Call the method on the helper object
     #  4. Call super
     #
-    def method_missing(name, *args, &block)
+    ruby2_keywords def method_missing(name, *args, &block)
       if current_arbre_element.respond_to?(name)
         current_arbre_element.send name, *args, &block
       elsif assigns && assigns.has_key?(name)
@@ -207,7 +208,7 @@ module Arbre
     # which will be rendered (#to_s) inside ActionView::Base#capture.
     # We do not want such elements added to self, so we push a dummy
     # current_arbre_element.
-    def helper_capture(name, *args, &block)
+    ruby2_keywords def helper_capture(name, *args, &block)
       s = ""
       within(Element.new) { s = helpers.send(name, *args, &block) }
       s.is_a?(Element) ? s.to_s : s

--- a/lib/arbre/element_collection.rb
+++ b/lib/arbre/element_collection.rb
@@ -20,6 +20,12 @@ module Arbre
         element.to_s
       end.join('').html_safe
     end
+
+    def render_in(context)
+      self.collect do |element|
+        element.render_in(context)
+      end.join('').html_safe
+    end
   end
 
 end

--- a/lib/arbre/html/document.rb
+++ b/lib/arbre/html/document.rb
@@ -25,6 +25,12 @@ module Arbre
         doctype + super
       end
 
+      def render_in(context = arbre_context)
+        context.output_buffer << doctype
+        super
+        context.output_buffer
+      end
+
       protected
 
       def build_head

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -100,6 +100,10 @@ module Arbre
         indent(opening_tag, content, closing_tag).html_safe
       end
 
+      def render_in(context = arbre_context)
+        indent_in_context(context)
+      end
+
       private
 
       def opening_tag
@@ -134,6 +138,31 @@ module Arbre
         html << "\n"
 
         html
+      end
+
+      def indent_in_context(context)
+        spaces = ' ' * indent_level * INDENT_SIZE
+
+        pos = context.output_buffer.tell
+
+        if no_child? || child_is_text?
+          if self_closing_tag?
+            context.output_buffer << spaces << opening_tag.sub( />$/, '/>' )
+          else
+            # one line
+            context.output_buffer << spaces << opening_tag << children.to_s << closing_tag
+          end
+        else
+          # multiple lines
+          context.output_buffer << spaces << opening_tag << "\n"
+          children.render_in(context)
+          context.output_buffer << spaces << closing_tag
+        end
+
+        context.output_buffer << "\n"
+
+        context.output_buffer.seek(pos)
+        context.output_buffer.read
       end
 
       def self_closing_tag?

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -143,26 +143,27 @@ module Arbre
       def indent_in_context(context)
         spaces = ' ' * indent_level * INDENT_SIZE
 
-        pos = context.output_buffer.tell
+        pos = context.output_buffer.length
 
         if no_child? || child_is_text?
           if self_closing_tag?
-            context.output_buffer << spaces << opening_tag.sub( />$/, '/>' )
+            context.output_buffer << spaces << opening_tag.sub( />$/, '/>' ).html_safe
           else
             # one line
-            context.output_buffer << spaces << opening_tag << children.to_s << closing_tag
+            context.output_buffer << spaces << opening_tag.html_safe
+            children.render_in(context)
+            context.output_buffer << closing_tag.html_safe
           end
         else
           # multiple lines
-          context.output_buffer << spaces << opening_tag << "\n"
+          context.output_buffer << spaces << opening_tag.html_safe << "\n"
           children.render_in(context)
-          context.output_buffer << spaces << closing_tag
+          context.output_buffer << spaces << closing_tag.html_safe
         end
 
         context.output_buffer << "\n"
 
-        context.output_buffer.seek(pos)
-        context.output_buffer.read
+        context.output_buffer[pos..].html_safe
       end
 
       def self_closing_tag?

--- a/lib/arbre/html/text_node.rb
+++ b/lib/arbre/html/text_node.rb
@@ -33,6 +33,10 @@ module Arbre
       def to_s
         ERB::Util.html_escape(@content.to_s)
       end
+
+      def render_in(context)
+        to_s.tap { |s| context.output_buffer << s }
+      end
     end
 
   end

--- a/lib/arbre/rails/forms.rb
+++ b/lib/arbre/rails/forms.rb
@@ -86,6 +86,12 @@ module Arbre
           children.to_s
         end
 
+        def render_in(context)
+          children.collect do |element|
+            element.render_in_or_to_s(context)
+          end.join('')
+        end
+
       end
 
     end

--- a/lib/arbre/rails/template_handler.rb
+++ b/lib/arbre/rails/template_handler.rb
@@ -25,7 +25,7 @@ module Arbre
         <<-END
         Arbre::Context.new(assigns, self) {
           #{source}
-        }.to_s
+        }.render_in(self).html_safe
         END
       end
     end

--- a/spec/arbre/integration/html_spec.rb
+++ b/spec/arbre/integration/html_spec.rb
@@ -5,12 +5,17 @@ describe Arbre do
   let(:helpers){ nil }
   let(:assigns){ {} }
 
+  def output_buffer(actx)
+    actx.render_in(actx) && actx.output_buffer.rewind && actx.output_buffer.read
+  end
+
   it "should render a single element" do
     actx = arbre {
       span "Hello World"
     }
     html = "<span>Hello World</span>\n"
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   it "should render a child element" do
@@ -25,6 +30,7 @@ describe Arbre do
 </span>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   it "should render an unordered list" do
@@ -43,6 +49,7 @@ HTML
 </ul>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   it "should allow local variables inside the tags" do
@@ -61,6 +68,7 @@ HTML
 </ul>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
 
@@ -82,6 +90,7 @@ HTML
 </div>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
 
@@ -101,6 +110,7 @@ HTML
 </div>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
 
@@ -120,6 +130,7 @@ HTML
 </div>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   it "should add content to the parent if the element is passed into block" do
@@ -139,6 +150,7 @@ HTML
 </div>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   it "should have the parent set on it" do
@@ -162,6 +174,7 @@ HTML
 <li>Hello World</li>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   it "should turn string return values into text nodes" do
@@ -185,6 +198,7 @@ HTML
 <tbody></tbody>
 HTML
     expect(actx.to_s).to eq(html)
+    expect(output_buffer actx).to eq(html)
   end
 
   describe "self-closing nodes" do
@@ -195,6 +209,7 @@ HTML
       }
       html = "<script type=\"text/javascript\"></script>\n"
       expect(actx.to_s).to eq(html)
+      expect(output_buffer actx).to eq(html)
     end
 
     it "should self-close meta tags" do
@@ -203,6 +218,7 @@ HTML
       }
       html = "<meta content=\"text/html; charset=utf-8\"/>\n"
       expect(actx.to_s).to eq(html)
+      expect(output_buffer actx).to eq(html)
     end
 
     it "should self-close link tags" do
@@ -211,6 +227,7 @@ HTML
       }
       html = "<link rel=\"stylesheet\"/>\n"
       expect(actx.to_s).to eq(html)
+      expect(output_buffer actx).to eq(html)
     end
 
     Arbre::HTML::Tag::SELF_CLOSING_ELEMENTS.each do |tag|
@@ -220,6 +237,7 @@ HTML
         }
         html = "<#{tag}/>\n"
         expect(actx.to_s).to eq(html)
+        expect(output_buffer actx).to eq(html)
       end
     end
 
@@ -235,6 +253,7 @@ HTML
 <span>&lt;br /&gt;</span>
 HTML
       expect(actx.to_s).to eq(html)
+      expect(output_buffer actx).to eq(html)
     end
 
     it "should return html safe strings" do
@@ -253,6 +272,7 @@ HTML
 </span>
 HTML
       expect(actx.to_s).to eq(html)
+      expect(output_buffer actx).to eq(html)
     end
 
     it "should escape string contents when passed in block" do
@@ -269,6 +289,7 @@ HTML
 </span>
 HTML
       expect(actx.to_s).to eq(html)
+      expect(output_buffer actx).to eq(html)
     end
 
     it "should escape the contents of attributes" do

--- a/spec/arbre/integration/html_spec.rb
+++ b/spec/arbre/integration/html_spec.rb
@@ -6,7 +6,7 @@ describe Arbre do
   let(:assigns){ {} }
 
   def output_buffer(actx)
-    actx.render_in(actx) && actx.output_buffer.rewind && actx.output_buffer.read
+    actx.render_in(actx) && actx.output_buffer
   end
 
   it "should render a single element" do

--- a/spec/arbre/integration/html_spec.rb
+++ b/spec/arbre/integration/html_spec.rb
@@ -6,65 +6,74 @@ describe Arbre do
   let(:assigns){ {} }
 
   it "should render a single element" do
-    expect(arbre {
+    actx = arbre {
       span "Hello World"
-    }.to_s).to eq("<span>Hello World</span>\n")
+    }
+    html = "<span>Hello World</span>\n"
+    expect(actx.to_s).to eq(html)
   end
 
   it "should render a child element" do
-    expect(arbre {
+    actx = arbre {
       span do
         span "Hello World"
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <span>
   <span>Hello World</span>
 </span>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
   it "should render an unordered list" do
-    expect(arbre {
+    actx = arbre {
       ul do
         li "First"
         li "Second"
         li "Third"
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <ul>
   <li>First</li>
   <li>Second</li>
   <li>Third</li>
 </ul>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
-   it "should allow local variables inside the tags" do
-     expect(arbre {
+  it "should allow local variables inside the tags" do
+    actx = arbre {
        first = "First"
        second = "Second"
        ul do
          li first
          li second
        end
-     }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <ul>
   <li>First</li>
   <li>Second</li>
 </ul>
 HTML
-   end
+    expect(actx.to_s).to eq(html)
+  end
 
 
   it "should add children and nested" do
-    expect(arbre {
+    actx = arbre {
       div do
         ul
         li do
           li
         end
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <div>
   <ul></ul>
   <li>
@@ -72,32 +81,36 @@ HTML
   </li>
 </div>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
 
   it "should pass the element in to the block if asked for" do
-    expect(arbre {
+    actx = arbre {
       div do |d|
         d.ul do
           li
         end
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <div>
   <ul>
     <li></li>
   </ul>
 </div>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
 
   it "should move content tags between parents" do
-    expect(arbre {
+    actx = arbre {
       div do
         span(ul(li))
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <div>
   <span>
     <ul>
@@ -106,23 +119,26 @@ HTML
   </span>
 </div>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
   it "should add content to the parent if the element is passed into block" do
-    expect(arbre {
+    actx = arbre {
       div do |d|
         d.id = "my-tag"
         ul do
           li
         end
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <div id="my-tag">
   <ul>
     <li></li>
   </ul>
 </div>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
   it "should have the parent set on it" do
@@ -137,13 +153,15 @@ HTML
   end
 
   it "should set a string content return value with no children" do
-    expect(arbre {
+    actx = arbre {
       li do
         "Hello World"
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <li>Hello World</li>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
   it "should turn string return values into text nodes" do
@@ -158,40 +176,50 @@ HTML
   end
 
   it "should not render blank arrays" do
-    expect(arbre {
+    actx = arbre {
       tbody do
         []
       end
-    }.to_s).to eq <<-HTML
+    }
+    html = <<-HTML
 <tbody></tbody>
 HTML
+    expect(actx.to_s).to eq(html)
   end
 
   describe "self-closing nodes" do
 
     it "should not self-close script tags" do
-      expect(arbre {
+      actx = arbre {
         script type: 'text/javascript'
-      }.to_s).to eq("<script type=\"text/javascript\"></script>\n")
+      }
+      html = "<script type=\"text/javascript\"></script>\n"
+      expect(actx.to_s).to eq(html)
     end
 
     it "should self-close meta tags" do
-      expect(arbre {
+      actx = arbre {
         meta content: "text/html; charset=utf-8"
-      }.to_s).to eq("<meta content=\"text/html; charset=utf-8\"/>\n")
+      }
+      html = "<meta content=\"text/html; charset=utf-8\"/>\n"
+      expect(actx.to_s).to eq(html)
     end
 
     it "should self-close link tags" do
-      expect(arbre {
+      actx = arbre {
         link rel: "stylesheet"
-      }.to_s).to eq("<link rel=\"stylesheet\"/>\n")
+      }
+      html = "<link rel=\"stylesheet\"/>\n"
+      expect(actx.to_s).to eq(html)
     end
 
     Arbre::HTML::Tag::SELF_CLOSING_ELEMENTS.each do |tag|
       it "should self-close #{tag} tags" do
-        expect(arbre {
+        actx = arbre {
           send(tag)
-        }.to_s).to eq("<#{tag}/>\n")
+        }
+        html = "<#{tag}/>\n"
+        expect(actx.to_s).to eq(html)
       end
     end
 
@@ -200,11 +228,13 @@ HTML
   describe "html safe" do
 
     it "should escape the contents" do
-      expect(arbre {
+      actx = arbre {
         span("<br />")
-      }.to_s).to eq <<-HTML
+      }
+      html = <<-HTML
 <span>&lt;br /&gt;</span>
 HTML
+      expect(actx.to_s).to eq(html)
     end
 
     it "should return html safe strings" do
@@ -214,35 +244,41 @@ HTML
     end
 
     it "should not escape html passed in" do
-      expect(arbre {
+      actx = arbre {
         span(span("<br />"))
-      }.to_s).to eq <<-HTML
+      }
+      html = <<-HTML
 <span>
   <span>&lt;br /&gt;</span>
 </span>
 HTML
+      expect(actx.to_s).to eq(html)
     end
 
     it "should escape string contents when passed in block" do
-      expect(arbre {
+      actx = arbre {
         span {
           span {
             "<br />"
           }
         }
-      }.to_s).to eq <<-HTML
+      }
+      html = <<-HTML
 <span>
   <span>&lt;br /&gt;</span>
 </span>
 HTML
+      expect(actx.to_s).to eq(html)
     end
 
     it "should escape the contents of attributes" do
-      expect(arbre {
+      actx = arbre {
         span(class: "<br />")
-      }.to_s).to eq <<-HTML
+      }
+      html = <<-HTML
 <span class="&lt;br /&gt;"></span>
 HTML
+      expect(actx.to_s).to eq(html)
     end
 
   end

--- a/spec/arbre/unit/component_spec.rb
+++ b/spec/arbre/unit/component_spec.rb
@@ -31,7 +31,7 @@ describe Arbre::Component do
     expect(component.class_list).to include("mock_component")
   end
 
-  it "should render the object using the builder method name" do
+  it "should render (to_s) the object using the builder method name" do
     comp = expect(arbre {
       mock_component
     }.to_s).to eq <<-HTML
@@ -41,4 +41,14 @@ describe Arbre::Component do
 HTML
   end
 
+  it "should render (render_in) the object using the builder method name" do
+    context = arbre { mock_component }
+    output_buffer = context.render_in(context)
+
+    expect(output_buffer).to eq <<-HTML
+<div class="mock_component">
+  <h2>Hello World</h2>
+</div>
+HTML
+  end
 end

--- a/spec/arbre/unit/context_spec.rb
+++ b/spec/arbre/unit/context_spec.rb
@@ -27,7 +27,7 @@ describe Arbre::Context do
   end
 
   it "should use a cached version of the HTML for method delegation" do
-    expect(context).to receive(:to_s).once.and_return("<h1>札幌市北区</h1>")
+    expect(context).to receive(:render_in).once.and_return("<h1>札幌市北区</h1>")
     expect(context.index('<')).to eq(0)
     expect(context.index('<')).to eq(0)
   end

--- a/spec/arbre/unit/element_spec.rb
+++ b/spec/arbre/unit/element_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timeout'
 
 describe Arbre::Element do
 

--- a/spec/arbre/unit/html/tag_spec.rb
+++ b/spec/arbre/unit/html/tag_spec.rb
@@ -112,4 +112,13 @@ describe Arbre::HTML::Tag do
 
   end
 
+  describe "#render_in" do
+    before { tag.build "Hello World", id: "my_id" }
+
+    it "renders tag" do
+      html = tag.render_in(Arbre::Context.new)
+
+      expect(html).to eq "<tag id=\"my_id\">Hello World</tag>\n"
+    end
+  end
 end

--- a/spec/rails/integration/forms_spec.rb
+++ b/spec/rails/integration/forms_spec.rb
@@ -5,6 +5,7 @@ describe "Building forms" do
   let(:assigns){ {} }
   let(:helpers){ mock_action_view }
   let(:html) { form.to_s }
+  let(:output_buffer) { form.render_in(form) }
 
   describe "building a simple form for" do
 
@@ -33,6 +34,9 @@ describe "Building forms" do
       expect(html).to have_selector("form input[type=text]")
     end
 
+    it "should render equally with each strategy" do
+      expect(output_buffer).to eq html
+    end
   end
 
   describe "building a form with fields for" do
@@ -60,6 +64,10 @@ describe "Building forms" do
 
     it "should not render a div for the proxy" do
       expect(html).not_to have_selector("form div.fields_for_proxy")
+    end
+
+    it "should render equally with each strategy" do
+      expect(output_buffer).to eq html
     end
 
   end
@@ -98,6 +106,10 @@ describe "Building forms" do
 
     it "should correnctly nest elements within fields for" do
       expect(html).to have_selector("form > div.permissions > div.permissions_label label")
+    end
+
+    it "should render equally with each strategy" do
+      expect(output_buffer).to eq html
     end
   end
 


### PR DESCRIPTION
Improve the performance and interoperability with ActionView by implementing render_in alternative to to_s that appends to view_context.output_buffer.