### PR TITLE
Remove build_head and build_body from HTML::Document tag

### DIFF
--- a/lib/arbre/html/document.rb
+++ b/lib/arbre/html/document.rb
@@ -3,12 +3,6 @@ module Arbre
 
     class Document < Tag
 
-      def build(*args)
-        super
-        build_head
-        build_body
-      end
-
       def document
         self
       end
@@ -31,17 +25,6 @@ module Arbre
         context.output_buffer
       end
 
-      protected
-
-      def build_head
-        @head = head do
-          meta :"http-equiv" => "Content-type", content: "text/html; charset=utf-8"
-        end
-      end
-
-      def build_body
-        @body = body
-      end
     end
 
   end


### PR DESCRIPTION
The html tag contents should be populated by the caller using a block.

This class has no tests and probably has not been used directly since before its extraction from activeadmin in 2012, where it was subclassed (and these methods redefined) by Pages::Base.