### PR TITLE
Support Rails 7.1

### DIFF
--- a/lib/arbo/html/tag.rb
+++ b/lib/arbo/html/tag.rb
@@ -163,7 +163,7 @@ module Arbo
 
         context.output_buffer << "\n"
 
-        context.output_buffer[pos..].html_safe
+        context.output_buffer.to_str[pos..].html_safe
       end
 
       def self_closing_tag?


### PR DESCRIPTION
ActionView::OutputBuffer no longer inherits from ActiveSupport::SafeBuffer in Rails 7.1.